### PR TITLE
fix illegal cuda access error by add a sync

### DIFF
--- a/flockoff/validator/trainer.py
+++ b/flockoff/validator/trainer.py
@@ -78,6 +78,8 @@ def reset_gpu():
     """Reset GPU state and clear memory"""
     if torch.cuda.is_available():
         try:
+            # Synchronize to ensure all operations are completed
+            torch.cuda.synchronize()
             # Clear cache
             torch.cuda.empty_cache()
             # Reset device


### PR DESCRIPTION
Add CUDA synchronisation before GPU memory reset to prevent illegal memory access errors