### PR TITLE
fix: only normalise scores which are not cached

### DIFF
--- a/flockoff/validator/database.py
+++ b/flockoff/validator/database.py
@@ -21,12 +21,16 @@ class ScoreDB:
             raise DatabaseError(f"Database initialization failed: {str(e)}") from e
 
     def _init_db(self):
-        """Initialize the database with a table to store UID, hotkey, and score."""
+        """Initialize the database with a table to store UID, hotkey, raw_score, and normalized_score."""
         try:
             c = self.conn.cursor()
             c.execute(
                 """CREATE TABLE IF NOT EXISTS miner_scores
-                         (uid INTEGER, hotkey TEXT, score REAL, PRIMARY KEY (uid, hotkey))"""
+                         (uid INTEGER, 
+                          hotkey TEXT, 
+                          raw_score REAL, 
+                          normalized_score REAL, 
+                          PRIMARY KEY (uid, hotkey))"""
             )
 
             c.execute(
@@ -71,65 +75,108 @@ class ScoreDB:
             raise DatabaseError(f"Failed to update revision: {str(e)}") from e
 
     def insert_or_reset_uid(
-        self, uid: int, hotkey: str, base_score: float = 1.0 / 255.0
+        self, uid: int, hotkey: str, base_raw_score: float = 0.0, initial_normalized_score: float = 1.0 / 255.0
     ):
-        """Insert a new UID or reset its score if the hotkey has changed (UID recycled)."""
+        """Insert a new UID or reset its scores if the hotkey has changed (UID recycled).
+        
+        Args:
+            uid (int): The UID of the miner.
+            hotkey (str): The hotkey of the miner.
+            base_raw_score (float, optional): The initial raw score to set. 
+                                             Defaults to 0.0 if not provided by the caller.
+            initial_normalized_score (float, optional): The initial normalized score (weight).
+                                                        Defaults to 1.0 / 255.0 if not provided by the caller.
+        """
         try:
             c = self.conn.cursor()
             c.execute("SELECT hotkey FROM miner_scores WHERE uid = ?", (uid,))
             result = c.fetchone()
             if result is None or result[0] != hotkey:
+                # Insert new record or replace existing if hotkey changed for the UID
                 c.execute(
-                    "INSERT OR REPLACE INTO miner_scores (uid, hotkey, score) VALUES (?, ?, ?)",
-                    (uid, hotkey, base_score),
+                    """INSERT OR REPLACE INTO miner_scores 
+                         (uid, hotkey, raw_score, normalized_score) 
+                         VALUES (?, ?, ?, ?)""",
+                    (uid, hotkey, base_raw_score, initial_normalized_score),
                 )
+            # If UID and hotkey match, we don't reset scores, assuming they are current.
+            # Specific updates to raw_score or normalized_score will be handled by dedicated methods.
             self.conn.commit()
         except sqlite3.Error as e:
             logger.error(f"Failed to insert/reset UID {uid}: {str(e)}")
             raise DatabaseError(f"Failed to insert/reset UID: {str(e)}") from e
 
-    def update_score(self, uid: int, new_score: float):
-        """Update the score for a given UID"""
+    def update_raw_eval_score(self, uid: int, new_raw_score: float):
+        """Update the raw evaluation score for a given UID."""
         try:
             c = self.conn.cursor()
             c.execute(
-                "UPDATE miner_scores SET score = ? WHERE uid = ?", (new_score, uid)
+                "UPDATE miner_scores SET raw_score = ? WHERE uid = ?", (new_raw_score, uid)
             )
             if c.rowcount == 0:
-                # row absent – insert with unknown hotkey
-                c.execute(
-                    "INSERT INTO miner_scores (uid, hotkey, score) VALUES (?, '', ?)",
-                    (uid, new_score),
-                )
+                # If somehow a UID is being updated that wasn't inserted, log a warning or error.
+                logger.warning(f"Attempted to update raw_score for non-existent UID {uid}, no changes made.")
             self.conn.commit()
         except sqlite3.Error as e:
-            logger.error(f"Failed to update score for UID {uid}: {str(e)}")
-            raise DatabaseError(f"Failed to update score: {str(e)}") from e
+            logger.error(f"Failed to update raw_score for UID {uid}: {str(e)}")
+            raise DatabaseError(f"Failed to update raw_score: {str(e)}") from e
 
-    def get_scores(self, uids: list) -> list:
-        """Retrieve scores for a list of UIDs, defaulting to 0.0 if not found."""
+    def update_final_normalized_score(self, uid: int, new_normalized_score: float):
+        """Update the final normalized score for a given UID."""
         try:
             c = self.conn.cursor()
             c.execute(
-                f"SELECT uid, score FROM miner_scores WHERE uid IN ({','.join('?'*len(uids))})",
-                uids,
+                "UPDATE miner_scores SET normalized_score = ? WHERE uid = ?", (new_normalized_score, uid)
             )
-            scores_dict = {uid: score for uid, score in c.fetchall()}
-            return [scores_dict.get(uid, 0.0) for uid in uids]
+            if c.rowcount == 0:
+                logger.warning(f"Attempted to update normalized_score for non-existent UID {uid}, no changes made.")
+            self.conn.commit()
         except sqlite3.Error as e:
-            logger.error(f"Failed to get scores for UIDs {uids}: {str(e)}")
-            raise DatabaseError(f"Failed to retrieve scores: {str(e)}") from e
-    
-    def get_score(self, uid: int) -> float:
-        """Retrieve the score for a given UID, defaulting to 0.0 if not found."""
+            logger.error(f"Failed to update normalized_score for UID {uid}: {str(e)}")
+            raise DatabaseError(f"Failed to update normalized_score: {str(e)}") from e
+
+    def get_raw_eval_score(self, uid: int) -> float | None:
+        """Retrieve the raw evaluation score for a given UID, defaulting to None if not found."""
         try:
             c = self.conn.cursor()
-            c.execute("SELECT score FROM miner_scores WHERE uid = ?", (uid,))
+            c.execute("SELECT raw_score FROM miner_scores WHERE uid = ?", (uid,))
+            result = c.fetchone()
+            return result[0] if result else None
+        except sqlite3.Error as e:
+            logger.error(f"Failed to get raw_score for UID {uid}: {str(e)}")
+            raise DatabaseError(f"Failed to retrieve raw_score: {str(e)}") from e
+
+    def get_all_normalized_scores(self, uids: list) -> list:
+        """Retrieve normalized scores for a list of UIDs, defaulting to 0.0 if not found."""
+        # This replaces the old get_scores for the purpose of initializing weights.
+        try:
+            c = self.conn.cursor()
+            # Ensure there are UIDs to prevent empty IN clause
+            if not uids:
+                return []
+            
+            placeholders = ','.join('?' * len(uids))
+            c.execute(
+                f"SELECT uid, normalized_score FROM miner_scores WHERE uid IN ({placeholders})",
+                uids,
+            )
+            scores_dict = {uid_val: score for uid_val, score in c.fetchall()}
+            # Default to 0.0 for UIDs not found in the database
+            return [scores_dict.get(uid_val, 0.0) for uid_val in uids]
+        except sqlite3.Error as e:
+            logger.error(f"Failed to get normalized_scores for UIDs {uids}: {str(e)}")
+            raise DatabaseError(f"Failed to retrieve normalized_scores: {str(e)}") from e
+    
+    def get_normalized_score(self, uid: int) -> float:
+        """Retrieve the normalized score for a given UID, defaulting to 0.0 if not found."""
+        try:
+            c = self.conn.cursor()
+            c.execute("SELECT normalized_score FROM miner_scores WHERE uid = ?", (uid,))
             result = c.fetchone()
             return result[0] if result else 0.0
         except sqlite3.Error as e:
-            logger.error(f"Failed to get score for UID {uid}: {str(e)}")
-            raise DatabaseError(f"Failed to retrieve score: {str(e)}") from e
+            logger.error(f"Failed to get normalized_score for UID {uid}: {str(e)}")
+            raise DatabaseError(f"Failed to retrieve normalized_score: {str(e)}") from e
 
     def __del__(self):
         """Close the connection when the instance is destroyed."""

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -373,7 +373,7 @@ class Validator:
                     and score_j not in (None, 0, constants.DEFAULT_SCORE)
                     and uid_j not in processed_uids
                 ):
-                    if math.isclose(score_i, score_j, rel_tol=1e-9):
+                    if math.isclose(score_i, score_j, rel_tol=1e-5):
                         bt.logging.debug(
                             f"Found similar raw score: {uid_i}({score_i}) and {uid_j}({score_j})"
                         )

--- a/tests/FlockDataset/validators/test_database.py
+++ b/tests/FlockDataset/validators/test_database.py
@@ -10,98 +10,144 @@ def db():
 
 
 def test_init_db(db):
-    """Test that the database initializes with the correct table."""
+    """Test that the database initializes with the correct table and columns."""
     c = db.conn.cursor()
     c.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='miner_scores'"
     )
     assert c.fetchone() is not None, "The 'miner_scores' table should be created"
+    c.execute("PRAGMA table_info(miner_scores)")
+    columns = {row[1] for row in c.fetchall()}
+    expected_columns = {"uid", "hotkey", "raw_score", "normalized_score"}
+    assert columns == expected_columns, f"Expected columns {expected_columns}, got {columns}"
 
 
 def test_insert_or_reset_uid(db):
-    """Test inserting or resetting UIDs with hotkeys."""
-    base = 1.0 / 255.0
+    """Test inserting or resetting UIDs with hotkeys, raw_score, and normalized_score."""
+    base_raw = 0.05  # Example base raw score
+    initial_norm = 0.0  # Example initial normalized score
 
     # Insert new UID
-    db.insert_or_reset_uid(1, "hotkey1")
-    scores = db.get_scores([1])
-    assert scores == [pytest.approx(base)], f"New UID should have score {base}"
+    db.insert_or_reset_uid(1, "hotkey1", base_raw, initial_norm)
+    raw_score = db.get_raw_eval_score(1)
+    norm_score = db.get_normalized_score(1)
+    assert raw_score == pytest.approx(base_raw), f"New UID should have raw_score {base_raw}"
+    assert norm_score == pytest.approx(initial_norm), f"New UID should have normalized_score {initial_norm}"
 
-    # Update score and check no reset with same hotkey
-    db.update_score(1, 5.0)
-    scores = db.get_scores([1])
-    assert scores == [5.0], "Score should be updated to 5.0"
-    db.insert_or_reset_uid(1, "hotkey1")
-    scores = db.get_scores([1])
-    assert scores == [5.0], "Score should remain 5.0 when hotkey is the same"
+    # Update scores and check no reset with same hotkey
+    db.update_raw_eval_score(1, 0.75)
+    db.update_final_normalized_score(1, 0.85)
+    raw_score = db.get_raw_eval_score(1)
+    norm_score = db.get_normalized_score(1)
+    assert raw_score == 0.75, "Raw score should be updated"
+    assert norm_score == 0.85, "Normalized score should be updated"
+    
+    db.insert_or_reset_uid(1, "hotkey1", base_raw, initial_norm) # This should not overwrite existing if hotkey matches
+    raw_score_after_reinsert = db.get_raw_eval_score(1)
+    norm_score_after_reinsert = db.get_normalized_score(1)
+    assert raw_score_after_reinsert == 0.75, "Raw score should remain after re-insert with same hotkey"
+    assert norm_score_after_reinsert == 0.85, "Normalized score should remain after re-insert with same hotkey"
 
-    # Reset score with different hotkey
-    db.insert_or_reset_uid(1, "hotkey2")
-    scores = db.get_scores([1])
-    assert scores == [
-        pytest.approx(base)
-    ], f"Score should reset to {base} with new hotkey"
-
-
-def test_update_score(db):
-    """Test updating scores for UIDs."""
-    # Insert UID and overwrite score
-    db.insert_or_reset_uid(1, "hotkey1")
-    db.update_score(1, 3.0)
-    scores = db.get_scores([1])
-    assert scores == [3.0], "Score should be updated to 3.0"
-
-    # Overwrite with a new value
-    db.update_score(1, 2.0)
-    scores = db.get_scores([1])
-    assert scores == [2.0], "Score should be overwritten to 2.0"
+    # Reset scores with different hotkey
+    new_base_raw = 0.06
+    new_initial_norm = 0.01
+    db.insert_or_reset_uid(1, "hotkey2", new_base_raw, new_initial_norm)
+    raw_score = db.get_raw_eval_score(1)
+    norm_score = db.get_normalized_score(1)
+    assert raw_score == pytest.approx(new_base_raw), f"Raw score should reset to {new_base_raw} with new hotkey"
+    assert norm_score == pytest.approx(new_initial_norm), f"Normalized score should reset to {new_initial_norm} with new hotkey"
 
 
-def test_get_scores(db):
-    """Test retrieving scores for UIDs."""
-    # Insert multiple UIDs
-    db.insert_or_reset_uid(1, "hotkey1")
-    db.insert_or_reset_uid(2, "hotkey2")
-    db.update_score(1, 10.0)
-    db.update_score(2, 20.0)
+def test_update_raw_eval_score(db):
+    """Test updating raw evaluation scores for UIDs."""
+    db.insert_or_reset_uid(1, "hotkey1", 0.1, 0.0)
+    db.update_raw_eval_score(1, 0.77)
+    raw_score = db.get_raw_eval_score(1)
+    assert raw_score == 0.77, "Raw score should be updated to 0.77"
+
+    # Test updating non-existent UID (should not raise error, no change)
+    db.update_raw_eval_score(2, 0.88) 
+    raw_score_2 = db.get_raw_eval_score(2)
+    assert raw_score_2 is None, "Raw score for non-existent UID 2 should be None"
+
+
+def test_update_final_normalized_score(db):
+    """Test updating final normalized scores for UIDs."""
+    db.insert_or_reset_uid(1, "hotkey1", 0.1, 0.0)
+    db.update_final_normalized_score(1, 0.99)
+    norm_score = db.get_normalized_score(1)
+    assert norm_score == 0.99, "Normalized score should be updated to 0.99"
+
+    # Test updating non-existent UID (should not raise error, no change)
+    db.update_final_normalized_score(2, 0.88)
+    norm_score_2 = db.get_normalized_score(2)
+    assert norm_score_2 == 0.0, "Normalized score for non-existent UID 2 should be default 0.0"
+
+
+def test_get_raw_eval_score(db):
+    """Test retrieving raw evaluation scores."""
+    # Test non-existing UID
+    score = db.get_raw_eval_score(1)
+    assert score is None, "Non-existing UID should return None for raw score"
+
+    # Insert UID and check raw score
+    db.insert_or_reset_uid(1, "hotkey1", 0.123, 0.0)
+    score = db.get_raw_eval_score(1)
+    assert score == 0.123, "Raw score should be 0.123"
+
+    # Update raw score and check
+    db.update_raw_eval_score(1, 0.456)
+    score = db.get_raw_eval_score(1)
+    assert score == 0.456, "Raw score should be updated to 0.456"
+
+def test_get_all_normalized_scores(db):
+    """Test retrieving all normalized scores for a list of UIDs."""
+    db.insert_or_reset_uid(1, "hotkey1", 0.1, 0.5)
+    db.insert_or_reset_uid(2, "hotkey2", 0.2, 0.6)
+    db.update_final_normalized_score(1, 0.55)
+    db.update_final_normalized_score(2, 0.66)
 
     # Get scores for existing UIDs
-    scores = db.get_scores([1, 2])
+    scores = db.get_all_normalized_scores([1, 2])
     assert len(scores) == 2, "Should return two scores"
-    assert scores[0] == 10.0, "UID 1 should have score 10.0"
-    assert scores[1] == 20.0, "UID 2 should have score 20.0"
+    assert scores[0] == 0.55, "UID 1 should have normalized score 0.55"
+    assert scores[1] == 0.66, "UID 2 should have normalized score 0.66"
 
     # Get score for non-existing UID
-    scores = db.get_scores([3])
-    assert scores == [0.0], "Non-existing UID should return 0.0"
+    scores = db.get_all_normalized_scores([3])
+    assert scores == [0.0], "Non-existing UID should return [0.0]"
 
     # Get scores for mixed UIDs
-    scores = db.get_scores([1, 3])
+    scores = db.get_all_normalized_scores([1, 3])
     assert len(scores) == 2, "Should return two scores"
-    assert scores[0] == 10.0, "Existing UID 1 should have score 10.0"
-    assert scores[1] == 0.0, "Non-existing UID 3 should have score 0.0"
+    assert scores[0] == 0.55, "Existing UID 1 should have normalized score 0.55"
+    assert scores[1] == 0.0, "Non-existing UID 3 should have normalized score 0.0"
+    
+    # Test with empty list
+    scores = db.get_all_normalized_scores([])
+    assert scores == [], "Empty UID list should return empty list"
 
 
-def test_get_score(db):
-    """Test retrieving a single score for a UID."""
+def test_get_normalized_score(db):
+    """Test retrieving a single normalized score for a UID."""
     # Test non-existing UID
-    score = db.get_score(1)
-    assert score == 0.0, "Non-existing UID should return 0.0"
+    score = db.get_normalized_score(1)
+    assert score == 0.0, "Non-existing UID should return 0.0 for normalized score"
 
-    # Insert UID and check score
-    db.insert_or_reset_uid(1, "hotkey1")
-    score = db.get_score(1)
-    assert score == pytest.approx(1.0 / 255.0), f"New UID should have score {1.0/255.0}"
+    # Insert UID and check initial normalized score
+    db.insert_or_reset_uid(1, "hotkey1", 0.1, 0.05)
+    score = db.get_normalized_score(1)
+    assert score == 0.05, "Initial normalized score should be 0.05"
 
-    # Update score and check
-    db.update_score(1, 5.0)
-    score = db.get_score(1)
-    assert score == 5.0, "Score should be updated to 5.0"
+    # Update normalized score and check
+    db.update_final_normalized_score(1, 0.75)
+    score = db.get_normalized_score(1)
+    assert score == 0.75, "Normalized score should be updated to 0.75"
 
     # Test with multiple UIDs
-    db.insert_or_reset_uid(2, "hotkey2")
-    db.update_score(2, 10.0)
-    score1 = db.get_score(1)
-    score2 = db.get_score(2)
-    assert score1 == 5.0, "UID 1 should have score 5.0"
-    assert score2 == 10.0, "UID 2 should have score 10.0"
+    db.insert_or_reset_uid(2, "hotkey2", 0.2, 0.15)
+    db.update_final_normalized_score(2, 0.85)
+    score1 = db.get_normalized_score(1)
+    score2 = db.get_normalized_score(2)
+    assert score1 == 0.75, "UID 1 normalized score should be 0.75"
+    assert score2 == 0.85, "UID 2 normalized score should be 0.85"

--- a/tests/FlockDataset/validators/test_scoring.py
+++ b/tests/FlockDataset/validators/test_scoring.py
@@ -43,7 +43,7 @@ def test_high_loss_evaluation():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_zero_loss_evaluation():
@@ -61,7 +61,7 @@ def test_zero_loss_evaluation():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_none_loss_evaluation():
@@ -79,7 +79,7 @@ def test_none_loss_evaluation():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_zero_benchmark_evaluation():
@@ -97,7 +97,7 @@ def test_zero_benchmark_evaluation():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_negative_benchmark_evaluation():
@@ -115,7 +115,7 @@ def test_negative_benchmark_evaluation():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_none_benchmark_evaluation():
@@ -133,7 +133,7 @@ def test_none_benchmark_evaluation():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_invalid_power():
@@ -151,7 +151,7 @@ def test_invalid_power():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_none_power():
@@ -169,7 +169,7 @@ def test_none_power():
         DEFAULT_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)
 
 
 def test_mismatched_competition_id():
@@ -187,4 +187,4 @@ def test_mismatched_competition_id():
         MISMATCH_COMPETITION_ID,
         DEFAULT_COMPETITION_ID,
     )
-    assert np.isclose(score, expected_score, rtol=1e-9)
+    assert np.isclose(score, expected_score, rtol=1e-5)


### PR DESCRIPTION
- Fix to normalise only new raw scores. Currently all cached scores are also being normalised which were already normalised.
- record raw score and normalised score (weights) in db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved score handling by separating raw evaluation scores from normalized scores for clearer processing and storage.
  - Enhanced database schema and methods to manage both raw and normalized scores independently.
  - Expanded and refined tests to verify correct handling of raw and normalized scores, improving reliability and consistency.
  - Enhanced logging to provide clearer information about score normalization status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->